### PR TITLE
翻訳もれ、プレースホルダに関する不具合の修正

### DIFF
--- a/app/Controller/RegisterController.php
+++ b/app/Controller/RegisterController.php
@@ -41,7 +41,7 @@ class RegisterController extends AppController {
         
         $ages = array();
         for ($i=0;$i<=100;$i++){
-            $ages+= array($i => $i."さい");
+            $ages+= array($i => $i);
         }
 
         $this->set('maxlength', NAME_MAX_LENGTH);
@@ -50,7 +50,6 @@ class RegisterController extends AppController {
     }
     //確認
     function confirm() {
-        
         //セッションが無かったらリダイレクト
         if ($this->Session->check('Register') == false){
             $this->redirect(array('action' => 'qrread'));
@@ -80,19 +79,7 @@ class RegisterController extends AppController {
            
        }
        
-       // 性別表示用
-       $disp_gender = "";
-       if ($this->Session->read('Register.gender') == "male") $disp_gender = "男性(おとこのこ)";
-       if ($this->Session->read('Register.gender') == "female") $disp_gender = "女性(おんなのこ)";
-       if ($this->Session->read('Register.gender') == "other") $disp_gender = "その他(そのた)";
-       
-       // 年齢表示用
-       $disp_age = $this->Session->read('Register.age');
-       $disp_age .= "歳";
-       
        $this->set('register',$this->Session->read('Register'));
-       $this->set('disp_gender',$disp_gender);
-       $this->set('disp_age',$disp_age);
        
     }
     
@@ -100,7 +87,7 @@ class RegisterController extends AppController {
     function oath() {
         //セッションが無かったらリダイレクト
         if ($this->Session->check('Register') == false){
-            $this->redirect(array('action' => 'qrread'));
+           $this->redirect(array('action' => 'qrread'));
         }
         
         $this->set('register',$this->Session->read('Register'));  
@@ -108,7 +95,6 @@ class RegisterController extends AppController {
     
     //選手追加
     function registered() {
-        
         if ($this->request->is('post')) {
             //セッションが無かったらリダイレクト
             if ($this->Session->check('Register') == false){

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -19,7 +19,7 @@ msgid "スポーツタイムマシン選手宣誓"
 msgstr ""
 
 #: ./templates/Registers/auth.php:9
-msgid "わたし{0}は、"
+msgid "わたし%sは、"
 msgstr ""
 
 #: ./templates/Registers/auth.php:11
@@ -138,7 +138,7 @@ msgid "かかりの人をよんでください"
 msgstr ""
 
 #: ./templates/Registers/qrcode.php:40
-msgid "よみこみました。かくにんちゅうです… "
+msgid "よみこみました。かくにんちゅうです…"
 msgstr ""
 
 #: ./templates/Registers/qrcode.php:66
@@ -148,6 +148,9 @@ msgstr ""
 
 #: ./templates/Registers/qrcode.php:87
 msgid "カメラが利用できません。"
+msgstr ""
+
+msgid "カメラ切り替え"
 msgstr ""
 
 #: ./templates/Registers/qrcode.php:111
@@ -177,7 +180,7 @@ msgid "さい"
 msgstr ""
 
 #: ./templates/Registers/registered.php:3
-msgid "せんしゅとしてとうろくされました！\nあなたのせんしゅページは\n{0}\nです"
+msgid "せんしゅとしてとうろくされました！\nあなたのせんしゅページは\n%s\nです"
 msgstr ""
 
 #: ./templates/Registers/registered.php:6

--- a/app/Locale/eng/LC_MESSAGES/default.po
+++ b/app/Locale/eng/LC_MESSAGES/default.po
@@ -19,8 +19,8 @@ msgid "スポーツタイムマシン選手宣誓"
 msgstr "Sports Time Machine Player Oath"
 
 #: ./templates/Registers/auth.php:9
-msgid "わたし{0}は、"
-msgstr "I, {0},"
+msgid "わたし%sは、"
+msgstr "I, %s,"
 
 #: ./templates/Registers/auth.php:11
 msgid "スポーツマンシップにのっとり正々堂々とプレイします。"
@@ -28,7 +28,7 @@ msgstr "promise to play fairly and with good sportsmanship."
 
 #: ./templates/Registers/auth.php:12
 msgid "タイムマシンマンシップにのっとり情報を<br/>未来の自分・家族・友達・小松・石川・地球・宇宙のために残します。"
-msgstr "With \"time machinemanship,\" I’ll save information to help everyone playing together.<br/>(The data we collect this time will be deleted after the event is over.)"
+msgstr "With &quot;time machinemanship,&quot; I’ll save information to help everyone playing together.<br/>(The data we collect this time will be deleted after the event is over.)"
 
 #: ./templates/Registers/auth.php:17
 msgid "せんせいしません"
@@ -101,22 +101,28 @@ msgstr "If this screen keeps appearing, please call a staff member."
 
 #: ./templates/Registers/error.php:6
 msgid "さいしょの画面へ"
-msgstr "To the initial screen"
+msgstr "To the top screen"
 
 #: ./templates/Registers/inputcode.php:68
 msgid "せんしゅカードに書いてあるコードを書いて\n「よみこみ」ボタンを押してください"
-msgstr "Please enter the code written on your player card and press the \"scan\" button."
+msgstr "Please enter the code written on your player card and press the &quot;scan&quot; button."
 
 #: ./templates/Registers/inputcode.php:75
 msgid "よみこみ"
 msgstr "Scan"
 
 #: ./templates/Registers/inputcode.php:88
+msgid "とうろくされたせんしゅコードではありません"
+msgstr "This is not a registered player code."
+
+#: ./templates/Registers/inputcode.php:91
+msgid "このせんしゅコードはすでにとうろくされています"
+msgstr "This player code is already registered."
+
 #: ./templates/Registers/qrcode.php:121
 msgid "とうろくされたせんしゅQRコードではありません"
 msgstr "This is not a registered player QR code."
 
-#: ./templates/Registers/inputcode.php:91
 #: ./templates/Registers/qrcode.php:124
 msgid "このせんしゅQRコードはすでにとうろくされています"
 msgstr "This player QR code is already registered."
@@ -132,7 +138,7 @@ msgid "かかりの人をよんでください"
 msgstr "Please call a staff member."
 
 #: ./templates/Registers/qrcode.php:40
-msgid "よみこみました。かくにんちゅうです… "
+msgid "よみこみました。かくにんちゅうです…"
 msgstr "Scanned successfully. Verifying…"
 
 #: ./templates/Registers/qrcode.php:66
@@ -143,6 +149,9 @@ msgstr "Please scan the QR code on your player card."
 #: ./templates/Registers/qrcode.php:87
 msgid "カメラが利用できません。"
 msgstr "The camera is not available."
+
+msgid "カメラ切り替え"
+msgstr "Switch camera"
 
 #: ./templates/Registers/qrcode.php:111
 msgid "QRコードがよみこめないときはこちら"
@@ -171,8 +180,8 @@ msgid "さい"
 msgstr "Years old"
 
 #: ./templates/Registers/registered.php:3
-msgid "せんしゅとしてとうろくされました！\nあなたのせんしゅページは\n{0}\nです"
-msgstr "You have been registered as a player!\nYour player page is \n{0} ."
+msgid "せんしゅとしてとうろくされました！\nあなたのせんしゅページは\n%s\nです"
+msgstr "You have been registered as a player!\nYour player page is \n%s"
 
 #: ./templates/Registers/registered.php:6
 #: ./templates/Registers/registered_noname.php:6
@@ -181,7 +190,7 @@ msgstr "Got it"
 
 #: ./templates/element/header.php:6
 msgid "最初の画面へ"
-msgstr "To the initial screen"
+msgstr "To the top screen"
 
 #: ./templates/element/header.php:9
 msgid "せんしゅとうろくマシン"

--- a/app/Locale/kor/LC_MESSAGES/default.po
+++ b/app/Locale/kor/LC_MESSAGES/default.po
@@ -19,8 +19,8 @@ msgid "スポーツタイムマシン選手宣誓"
 msgstr "스포츠 타임머신 선수 선서"
 
 #: ./templates/Registers/auth.php:9
-msgid "わたし{0}は、"
-msgstr "저 {0}는"
+msgid "わたし%sは、"
+msgstr "저 %s는"
 
 #: ./templates/Registers/auth.php:11
 msgid "スポーツマンシップにのっとり正々堂々とプレイします。"
@@ -138,7 +138,7 @@ msgid "かかりの人をよんでください"
 msgstr "담당자를 불러주세요."
 
 #: ./templates/Registers/qrcode.php:40
-msgid "よみこみました。かくにんちゅうです… "
+msgid "よみこみました。かくにんちゅうです…"
 msgstr "스캔 후 체크 중입니다…"
 
 #: ./templates/Registers/qrcode.php:66
@@ -149,6 +149,9 @@ msgstr "선수 카드의 QR코드를 스캔해 주세요."
 #: ./templates/Registers/qrcode.php:87
 msgid "カメラが利用できません。"
 msgstr "카메라를 사용할 수 없습니다."
+
+msgid "カメラ切り替え"
+msgstr "카메라 전환"
 
 #: ./templates/Registers/qrcode.php:111
 msgid "QRコードがよみこめないときはこちら"
@@ -177,8 +180,8 @@ msgid "さい"
 msgstr "세"
 
 #: ./templates/Registers/registered.php:3
-msgid "せんしゅとしてとうろくされました！\nあなたのせんしゅページは\n{0}\nです"
-msgstr "선수로 등록되었습니다!\n당신의 선수 페이지는\n{0}"
+msgid "せんしゅとしてとうろくされました！\nあなたのせんしゅページは\n%s\nです"
+msgstr "선수로 등록되었습니다!\n당신의 선수 페이지는\n%s"
 
 #: ./templates/Registers/registered.php:6
 #: ./templates/Registers/registered_noname.php:6

--- a/app/View/Register/confirm.ctp
+++ b/app/View/Register/confirm.ctp
@@ -23,13 +23,17 @@ $(function(){
         <div class="input_disp">
             <?= __("せいべつ")?>
             <div class="detail">
-                <?php echo $disp_gender; ?>
+                <?php 
+                    if ($register['gender'] == "male") echo __("男性(おとこのこ)");
+                    if ($register['gender'] == "female") echo __("女性(おんなのこ)");
+                    if ($register['gender'] == "other") echo __("その他(そのた)");
+                 ?>
             </div>
         </div>
         <div class="input_disp" style="margin-bottom: 8px;">
             <?= __("ねんれい")?>
             <div class="detail">
-                <?php echo $disp_age; ?>
+                <?php echo $register['age'].__("さい") ?>
             </div>
         </div>
         <?php echo $this->Form->button(__('やりなおし'),array('label' => false, 'class' => 'btn', 'id' => 'prev')); ?>        

--- a/app/View/Register/input_code.ctp
+++ b/app/View/Register/input_code.ctp
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-//読み込まれたQRコードが既に選手登録済み、もしくは、予め登録されていないQRコードかチェック
+// 読み込まれたQRコードが既に選手登録済み、もしくは、予め登録されていないQRコードかチェック
 function checkPlayerRegister_Ajax(code){
     var url = "<?php echo $this->Html->webroot . 'register/check_input'; ?>";
     var data = { code : code};
@@ -75,7 +75,7 @@ $(function(){
         <?php echo $this->Form->text('input_code',array('label' => false, 'class' => "input" , "maxlength" => 8, 'autocomplete' => 'off')); ?>
     </div>
     <div>
-        <?php echo $this->Form->button('よみこみ',array('type' => 'button', 'div' => false, 'id' => 'read', 'class' => 'btn')) ?>
+        <?php echo $this->Form->button(__('よみこみ'),array('type' => 'button', 'div' => false, 'id' => 'read', 'class' => 'btn')) ?>
     </div>
     <?php echo $this->Form->hidden('player_id'); ?>
 </div>

--- a/app/View/Register/oath.ctp
+++ b/app/View/Register/oath.ctp
@@ -15,7 +15,7 @@ $(function(){
     <div class="oath">
         <div class="text-center" style="padding:20px 16px;"><?=__("スポーツタイムマシン選手宣誓")?></div>
         <div class="text-left">
-            <p><?=__("わたし{0}は、", $register['name'])?></p>
+            <p><?=__("わたし%sは、", h($register['name']))?></p>
             <p>・<?=__("スポーツマンシップにのっとり正々堂々とプレイします。")?></p>
             <p>・<?= nl2br(__("タイムマシンマンシップにのっとり情報を<br/>未来の自分・家族・友達・小松・石川・地球・宇宙のために残します。")) ?></p>
         </div>

--- a/app/View/Register/qrread.ctp
+++ b/app/View/Register/qrread.ctp
@@ -111,7 +111,7 @@ $(function(){
 <form action="<?php echo $this->Html->webroot?>Register/registername" id="QrreadForm" method="post" accept-charset="utf-8">
 
 <div class="cameraLogin">
-    <button id="turnCamera" style="margin-bottom:5px; padding: 5px; -webkit-appearance: none; background-color: #eee;"><?= $this->Html->image('turn_camera.png', ['alt' => 'カメラ切り替え']); ?></button>
+    <button id="turnCamera" style="margin-bottom:5px; padding: 5px; -webkit-appearance: none; background-color: #eee;"><?= $this->Html->image('turn_camera.png', ['alt' => __('カメラ切り替え')]); ?></button>
     <div class="camera">
         <video id="video" autoplay width="400" height="300"></video>
         <canvas id="canvas" width="640" height="480"></canvas>

--- a/app/View/Register/registered.ctp
+++ b/app/View/Register/registered.ctp
@@ -8,7 +8,7 @@ $(function(){
 </script>
 <div class="clear">
     <div class="info">
-        <?= nl2br(__("せんしゅとしてとうろくされました！\nあなたのせんしゅページは\n{0}\nです", "http://www.sptmy.net/p/".$player_id)) ?><br />
+        <?= nl2br(__("せんしゅとしてとうろくされました！\nあなたのせんしゅページは\n%s\nです", h("http://www.sptmy.net/p/".$player_id))) ?><br />
     </div>
     <div>
         <?php echo $this->Form->button(__('わかりました'),array('label' => false, 'class' => 'btn', 'id' => 'first')); ?>    

--- a/app/View/Register/registername.ctp
+++ b/app/View/Register/registername.ctp
@@ -72,7 +72,13 @@ $(function(){
         <div style="margin-top: 16px;"></div>
                 <div><?=__("ねんれいを選んでください")?></div>
                 <div>
-                    <?php echo $this->Form->select('age', $ages, array('label'=>false, 'class' => 'btn', 'default' => $register['age'], 'empty' => false)); ?>  
+                    <?php 
+                        $selectAges = [];
+                        foreach ($ages as $age) {
+                            $selectAges []= $age.__("さい");
+                        }
+                    ?>
+                    <?php echo $this->Form->select('age', $selectAges, array('label'=>false, 'class' => 'btn', 'default' => $register['age'], 'empty' => false)); ?>  
                 </div>
                 <br />
                 <?php echo $this->Form->hidden('player_id'); ?>


### PR DESCRIPTION
# 修正項目

## QRコード読み込み画面
・「よみこみました。かくにんちゅうです…」の翻訳設定漏れの修正

## コード手動入力画面
英語版において、
・「とうろくされたせんしゅコードではありません」
「このせんしゅコードはすでにとうろくされています」
の翻訳設定漏れの修正

・「よみこみ」ボタンの翻訳設定漏れの修正

## 選手情報入力画面
・年齢のセレクトボックスの「さい」が翻訳されていなかった不具合の修正

## 選手情報確認画面
・性別・年齢の表示が翻訳されていなかった不具合の修正

## 選手宣誓画面
・変数を入れるプレースホルダが正しく機能していなかった不具合の修正
・英語版において、ダブルクオーテーションがエスケープされていなかった不具合の修正

## 登録完了画面
・変数を入れるプレースホルダが正しく機能していなかった不具合の修正

## 全体
英語版「最初の画面へ」の英訳を`To the initial screen`から`To the top screen`に変更
